### PR TITLE
Add timestamps to record responses

### DIFF
--- a/lib/rock_rms/response/attribute.rb
+++ b/lib/rock_rms/response/attribute.rb
@@ -6,7 +6,7 @@ module RockRMS
         name: 'Name',
         key: 'Key',
         description: 'Description'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/attribute_value.rb
+++ b/lib/rock_rms/response/attribute_value.rb
@@ -6,7 +6,7 @@ module RockRMS
         value: 'Value',
         value_as_number: 'ValueAsNumeric',
         entity_id: 'EntityId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/base.rb
+++ b/lib/rock_rms/response/base.rb
@@ -1,6 +1,11 @@
 module RockRMS
   module Response
     class Base
+      TIMESTAMPS = {
+        created_date_time: "CreatedDateTime",
+        modified_date_time: "ModifiedDateTime",
+      }.freeze
+
       attr_reader :data
 
       def self.format(data)

--- a/lib/rock_rms/response/batch.rb
+++ b/lib/rock_rms/response/batch.rb
@@ -12,7 +12,7 @@ module RockRMS
         is_campus: 'Campus',
         status: 'Status',
         foreign_key: 'ForeignKey'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/block.rb
+++ b/lib/rock_rms/response/block.rb
@@ -6,7 +6,7 @@ module RockRMS
         name: 'Name',
         block_type: 'BlockType',
         page_id: 'PageId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/block_type.rb
+++ b/lib/rock_rms/response/block_type.rb
@@ -7,7 +7,7 @@ module RockRMS
         description: 'Description',
         category: 'Category',
         path: 'Path'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/campus.rb
+++ b/lib/rock_rms/response/campus.rb
@@ -12,7 +12,7 @@ module RockRMS
         phone_number: 'PhoneNumber',
         service_times: 'ServiceTimes',
         guid: 'Guid'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/defined_type.rb
+++ b/lib/rock_rms/response/defined_type.rb
@@ -8,7 +8,7 @@ module RockRMS
         defined_values: 'DefinedValues',
         order: 'Order',
         value: 'Value',
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/defined_value.rb
+++ b/lib/rock_rms/response/defined_value.rb
@@ -7,7 +7,7 @@ module RockRMS
         description: 'Description',
         order: 'Order',
         value: 'Value',
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/fund.rb
+++ b/lib/rock_rms/response/fund.rb
@@ -6,7 +6,7 @@ module RockRMS
         campus_id: 'CampusId',
         name: 'Name',
         gl_code: 'GlCode'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/gateway.rb
+++ b/lib/rock_rms/response/gateway.rb
@@ -5,7 +5,7 @@ module RockRMS
         id: 'Id',
         name: 'Name',
         active: 'IsActive'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/group.rb
+++ b/lib/rock_rms/response/group.rb
@@ -10,7 +10,7 @@ module RockRMS
         is_active: 'IsActive',
         guid: 'Guid',
         members: 'Members'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         result = to_h(MAP, data)

--- a/lib/rock_rms/response/group_location.rb
+++ b/lib/rock_rms/response/group_location.rb
@@ -6,7 +6,7 @@ module RockRMS
         group_id: 'GroupId',
         location_id: 'LocationId',
         guid: 'Guid'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         result = to_h(MAP, data)

--- a/lib/rock_rms/response/history.rb
+++ b/lib/rock_rms/response/history.rb
@@ -9,7 +9,7 @@ module RockRMS
         old_value: 'OldValue',
         new_value: 'NewValue',
         alias_id: 'CreatedByPersonAliasId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/location.rb
+++ b/lib/rock_rms/response/location.rb
@@ -15,7 +15,7 @@ module RockRMS
         latitude: 'Latitude',
         longitude: 'Longitude',
         guid: 'Guid'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/page.rb
+++ b/lib/rock_rms/response/page.rb
@@ -7,7 +7,7 @@ module RockRMS
         page_title: 'PageTitle',
         browser_title: 'BrowserTitle',
         blocks: 'Blocks'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/payment_detail.rb
+++ b/lib/rock_rms/response/payment_detail.rb
@@ -8,7 +8,7 @@ module RockRMS
         foreign_key: 'ForeignKey',
         payment_type_id: 'CurrencyTypeValueId',
         masked_number: 'AccountNumberMasked'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/person.rb
+++ b/lib/rock_rms/response/person.rb
@@ -11,7 +11,7 @@ module RockRMS
         giving_group_id: 'GivingGroupId',
         alias_id:   'PrimaryAliasId',
         connection_status_value_id: 'ConnectionStatusValueId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/phone_number.rb
+++ b/lib/rock_rms/response/phone_number.rb
@@ -8,7 +8,7 @@ module RockRMS
         number_type_value_id: 'NumberTypeValueId',
         formatted: 'NumberFormatted',
         formatted_with_cc: 'NumberFormattedWithCountryCode'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/recurring_donation.rb
+++ b/lib/rock_rms/response/recurring_donation.rb
@@ -17,7 +17,7 @@ module RockRMS
         transaction_code: 'TransactionCode',
         transaction_type_id: 'TransactionTypeValueId',
         summary: 'Summary'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         result = to_h(MAP, data)

--- a/lib/rock_rms/response/recurring_donation_details.rb
+++ b/lib/rock_rms/response/recurring_donation_details.rb
@@ -7,7 +7,7 @@ module RockRMS
         fund_id: 'AccountId',
         entity_type_id: 'EntityTypeId',
         entity_id: 'EntityId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/registration.rb
+++ b/lib/rock_rms/response/registration.rb
@@ -10,7 +10,7 @@ module RockRMS
         registration_instance_id: 'RegistrationInstanceId',
         registration_instance: 'RegistrationInstance',
         registrants: 'Registrants'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/registration_instance.rb
+++ b/lib/rock_rms/response/registration_instance.rb
@@ -7,7 +7,7 @@ module RockRMS
         start_date: 'StartDateTime',
         end_date: 'EndDateTime',
         fund_id: 'AccountId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/saved_payment_method.rb
+++ b/lib/rock_rms/response/saved_payment_method.rb
@@ -10,7 +10,7 @@ module RockRMS
         payment_details: 'FinancialPaymentDetail',
         payment_detail_id: 'FinancialPaymentDetailId',
         reference_number: 'ReferenceNumber'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/service_job.rb
+++ b/lib/rock_rms/response/service_job.rb
@@ -7,7 +7,7 @@ module RockRMS
         active: 'IsActive',
         description: 'Description',
         cron: 'CronExpression'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/transaction.rb
+++ b/lib/rock_rms/response/transaction.rb
@@ -15,7 +15,7 @@ module RockRMS
         payment_details: 'FinancialPaymentDetail',
         payment_detail_id: 'FinancialPaymentDetailId',
         transaction_type_id: 'TransactionTypeValueId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
 
       def format_single(data)

--- a/lib/rock_rms/response/transaction_detail.rb
+++ b/lib/rock_rms/response/transaction_detail.rb
@@ -9,7 +9,7 @@ module RockRMS
         amount: 'Amount',
         entity_type_id: 'EntityTypeId',
         entity_id: 'EntityId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(response)
         response        = to_h(MAP, response)

--- a/lib/rock_rms/response/workflow_action_type.rb
+++ b/lib/rock_rms/response/workflow_action_type.rb
@@ -6,7 +6,7 @@ module RockRMS
         name: 'Name',
         activity_type_id: 'ActivityTypeId',
         order: 'Order'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         to_h(MAP, data)

--- a/lib/rock_rms/response/workflow_activity_type.rb
+++ b/lib/rock_rms/response/workflow_activity_type.rb
@@ -8,7 +8,7 @@ module RockRMS
         order: 'Order',
         actions: 'ActionTypes',
         workflow_type_id: 'WorkflowTypeId'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/lib/rock_rms/response/workflow_type.rb
+++ b/lib/rock_rms/response/workflow_type.rb
@@ -8,7 +8,7 @@ module RockRMS
         description: 'Description',
         summary: 'SummaryViewText',
         activities: 'ActivityTypes'
-      }.freeze
+      }.merge(TIMESTAMPS).freeze
 
       def format_single(data)
         response = to_h(MAP, data)

--- a/spec/rock_rms/response/attribute_value_spec.rb
+++ b/spec/rock_rms/response/attribute_value_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RockRMS::Response::AttributeValue, type: :model do
 
     it 'has the correct number keys' do
       keys = result.first.keys
-      expect(keys.count).to eq(4)
+      expect(keys.count).to eq(6)
     end
 
     it 'translates keys' do
@@ -23,6 +23,8 @@ RSpec.describe RockRMS::Response::AttributeValue, type: :model do
         expect(r[:value]).to eq(p['Value'])
         expect(r[:value_as_number]).to eq(p['ValueAsNumeric'])
         expect(r[:entity_id]).to eq(p['EntityId'])
+        expect(r[:created_date_time]).to eq(p['CreatedDateTime'])
+        expect(r[:modified_date_time]).to eq(p['ModifiedDateTime'])
       end
     end
   end

--- a/spec/rock_rms/response/recurring_donation_spec.rb
+++ b/spec/rock_rms/response/recurring_donation_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe RockRMS::Response::RecurringDonation, type: :model do
         transaction_code
         transaction_type_id
         summary
+        created_date_time
+        modified_date_time
       ]
 
       expect(response.keys).to eq(expected_keys)


### PR DESCRIPTION
I’m using this gem (which is great, btw!) to modify a custom importer for Cru’s MPDX product.

Their domain model requires creation/update info.

—-

Something to note:

I’m game to change the field names here to be a little more standard to how Rails would handle them, ex: `created_at`/`updated_at` - but also fine to keep ask is.

Whichever you’d like, I’m more than happy to facilitate.

Thanks!