### PR TITLE
Add support for authorization_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ Add this line to your application's Gemfile:
 
 ### Usage
 ````ruby
+  # Authenticating with username and password
   client = RockRMS::Client.new(
     url: ...,
     username: ...,
     password: ...,
+  )
+
+  # Authenticating with authorization token
+  client = RockRMS::Client.new(
+    url: ...,
+    authorization_token: ...,
   )
 
   # Find a specific person

--- a/spec/rock_rms/client_spec.rb
+++ b/spec/rock_rms/client_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe RockRMS::Client do
     }
   end
   let(:attrs_without_logging) { attrs.merge(logger: false) }
+  let(:attrs_without_authentication)  do
+    {
+      url: 'http://some-rock-uri.com',
+      username: nil,
+      password: nil,
+      authorization_token: nil
+    }
+  end
 
   subject(:client) { described_class.new(**attrs_without_logging) }
   let(:noisy_client) { described_class.new(**attrs) }
@@ -19,14 +27,9 @@ RSpec.describe RockRMS::Client do
         .to raise_error(ArgumentError, /url/)
     end
 
-    it 'requries `username` param' do
-      expect { described_class.new }
-        .to raise_error(ArgumentError, /username/)
-    end
-
-    it 'requries `password` param' do
-      expect { described_class.new }
-        .to raise_error(ArgumentError, /password/)
+    it 'requries either `username` and `password` params or `authorization_token` param' do
+      expect { described_class.new(attrs_without_authentication) }
+        .to raise_error(ArgumentError, /username and password or authorization_token/)
     end
 
     context 'url' do


### PR DESCRIPTION
I picked up the work from https://github.com/taylorbrooks/rock_rms/pull/33 and hopefully took it over the finish line.

We plan to use this gem for an integration we're building, and we would love to have support for `authorization_token` in the official version rather than using a fork.