### PR TITLE
Adjust boolean handling for patching lava shortcodes

### DIFF
--- a/lib/rock_rms/resources/lava_shortcode.rb
+++ b/lib/rock_rms/resources/lava_shortcode.rb
@@ -58,8 +58,8 @@ module RockRMS
         options['Name']          = name          if name
         options['Description']   = description   if description
         options['Documentation'] = documentation if documentation
-        options['IsActive']      = active        if active
-        options['IsSystem']      = is_system     if is_system
+        options['IsActive']      = active        unless active.nil?
+        options['IsSystem']      = is_system     unless is_system.nil?
         options['Markup']        = markup        if markup
         options['Parameters']    = parameters    if parameters
         options['TagName']       = tag_name      if tag_name

--- a/lib/rock_rms/version.rb
+++ b/lib/rock_rms/version.rb
@@ -1,3 +1,3 @@
 module RockRMS
-  VERSION = '8.15.0'.freeze
+  VERSION = '8.15.1'.freeze
 end


### PR DESCRIPTION
This change allows for passing `false` to `IsActive` and `IsSystem` flags.