### PR TITLE
fix the rspec warning in my other projects that use rock_rms gem when…

### DIFF
--- a/rock_rms.gemspec
+++ b/rock_rms.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.files         = `git ls-files`.split($/)
-  s.executables   = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  s.executables   = []
   s.test_files    = s.files.grep(%r{^(test)/})
 
   s.required_ruby_version = '>= 2.7'


### PR DESCRIPTION
… they need `rspec ...`


Do you ever get this in other project that use the gem?

```
be rspec spec/...
The `rspec` executable in the `rspec-core` gem is being loaded, but it's also present in other gems (rock_rms).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.
```

This is the fix.

  
  